### PR TITLE
feature/batch-throttled-messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
 		"prettier": true
 	},
 	"ava": {
-		"source": ["dist/**/*.js", "src/__tests__/**/*.js"]
+		"source": ["dist/urban-yeti.js", "src/__tests__/**/*.js"]
 	}
 }


### PR DESCRIPTION
Allow users to batch a throttled subscription. So instead of receiving the most recent message, you get an array with each message that has occurred since your last subscribe was called. The goal for this is to break work into chunks.